### PR TITLE
Add ember-cli-htmlbars >= 0.7.7 information

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This addon compiles posts and associated categories into fixtures, adds new rout
 ember install ember-blog
 ```
 
+Edit your application's `package.json` and make sure `ember-cli-htmlbars` is `>=0.7.7`. This addon requires htmlbars **0.7.7** or greater.
+
 ## Usage
 
 Documentation coming soon. **This is early stage, currently under testing**. In the meantime, see the `tests/dummy` app for example usage.


### PR DESCRIPTION
Add a final step for the install as this addon has a dependency that is not provided by ember-cli by default.

A new Ember CLI 0.2.5 application will have htmlbars version 0.7.6 which is one point release to low.

Fixes issue #7